### PR TITLE
Allow deferred configuring

### DIFF
--- a/projects/kolkov/ngx-metrika/src/lib/ngx-metrika.service.ts
+++ b/projects/kolkov/ngx-metrika/src/lib/ngx-metrika.service.ts
@@ -30,13 +30,12 @@ export class NgxMetrikaService {
   public hit = new EventEmitter<MetrikaHitEventOptions>();
   public reachGoal = new BehaviorSubject<MetrikaGoalEventOptions>({target: 'test'});
 
-  constructor(@Inject(YM_CONFIG) private ymConfig: NgxMetrikaConfig,
+  constructor(@Inject(YM_CONFIG) ymConfig: NgxMetrikaConfig,
               private router: Router,
               rendererFactory: RendererFactory2) {
     this.renderer = rendererFactory.createRenderer(null, null);
-    this.config = Object.assign(this.defaultConfig, ymConfig);
-    if (this.config.id) {
-      this.configure(this.config);
+    if (ymConfig && ymConfig.id) {
+      this.configure(ymConfig);
     }
   }
 
@@ -49,6 +48,8 @@ export class NgxMetrikaService {
   }
 
   configure(config: NgxMetrikaConfig) {
+    config = Object.assign({}, this.defaultConfig, config);
+    this.config = config;
     this.insertMetrika(config);
     this.checkCounter(config.id)
       .then(x => {


### PR DESCRIPTION
It seems like `NgxMetrikaService.configure()` could be used for deferred configuring but it does not actually work that way:

```ts
// app.module.ts

@NgModule({
  imports: [
    ...
    // Omit config parameter and configure later
    NgxMetrikaModule.forRoot(),
  ]
})
```

```ts
// app.component.ts

export class AppComponent implements OnInit {

  constructor(
    private ym: NgxMetrikaService,
    // Backend API service
    private api: MyApiService,
  ) {}

    ngOnInit() {
      // Fetch the config from the server and configure metrika
      // MyApiService.getYandexMetrikaConfig() returns the following object:
      // { id: ..., defer: true, webvisor: true, clickmap: true }
      this.api.getYandexMetrikaConfig().subscribe(config => this.ym.configure(config));
    }
```

The example above doesn't work properly due to following reasons:

1. `configure()` does not set default parameters (`triggerEvent: true`, `trackPageViews: true`) as the constructor does. You should set them explicitly in the config object.
2. `configure()` does not set `this.config` but `onHit()` and `onReachGoal()` need it.

I've done slight refactoring in this PR, so it is now possible to configure `NgxMetrikaService` as in the example above.
