### PR TITLE
Fix injecting script to document head

### DIFF
--- a/src/lib/ngx-metrika.service.ts
+++ b/src/lib/ngx-metrika.service.ts
@@ -1,4 +1,5 @@
 import {EventEmitter, Inject, Injectable, Renderer2, RendererFactory2} from '@angular/core';
+import { DOCUMENT } from '@angular/common';
 import {NavigationEnd, Router} from "@angular/router";
 import {
   CommonOptions,
@@ -30,9 +31,12 @@ export class NgxMetrikaService {
   public hit = new EventEmitter<MetrikaHitEventOptions>();
   public reachGoal = new BehaviorSubject<MetrikaGoalEventOptions>({target: 'test'});
 
-  constructor(@Inject(YM_CONFIG) private ymConfig: NgxMetrikaConfig,
-              private router: Router,
-              rendererFactory: RendererFactory2) {
+  constructor(
+    @Inject(YM_CONFIG) private ymConfig: NgxMetrikaConfig,
+    private router: Router,
+    rendererFactory: RendererFactory2,
+    @Inject(DOCUMENT) private document: Document,
+  ) {
     this.renderer = rendererFactory.createRenderer(null, null);
     this.config = Object.assign(this.defaultConfig, ymConfig);
     if (this.config.id) {
@@ -120,15 +124,15 @@ export class NgxMetrikaService {
       }
     });
 
-    const n = document.getElementsByTagName('script')[0];
-    const s = document.createElement('script');
+    const head = this.document.getElementsByTagName('head')[0];
+    const s = this.document.createElement('script');
     s.type = 'text/javascript';
     s.async = true;
     s.src = 'https://mc.yandex.ru/metrika/tag.js';
-    const insetScriptTag = () => n.parentNode.insertBefore(s, n);
+    const insetScriptTag = () => head.appendChild(s);
 
     if ((window as any).opera === '[object Opera]') {
-      document.addEventListener('DOMContentLoaded', insetScriptTag, false);
+      this.document.addEventListener('DOMContentLoaded', insetScriptTag, false);
     } else {
       insetScriptTag();
     }


### PR DESCRIPTION
The injection part didn't work for me.
`document.getElementsByTagName('script')[0]` didn't return any results for some reason, so `n.parentNode` (on line 128) is `undefined` and causes error when you try to `n.parentNode.insertBefore`.

Also replaced direct calls to `document` with [angular injected DOCUMENT](https://angular.io/api/common/DOCUMENT), which will help in Server Side Rendering.
There is still the `window`problem, though.